### PR TITLE
Filter out all node_modules

### DIFF
--- a/server/coverage-data.js
+++ b/server/coverage-data.js
@@ -56,11 +56,7 @@ if (IS_COVERAGE_ACTIVE) {
                     return false;
                 }
             }
-            if (filename.indexOf('/npm/node_modules') > 0) {
-                // this is a browser file?
-                return false;
-            }
-            if (filename.indexOf('node_modules/meteor') > 0) {
+            if (filename.indexOf('node_modules') > 0) {
                 // this is a browser file?
                 return false;
             }


### PR DESCRIPTION
Testing code coverage of Meteor on client-side is adding every .js file in the node_modules folder to the report.  This will filter them out.