### PR TITLE
Warn user when invalid .coverage.json

### DIFF
--- a/server/context/conf.js
+++ b/server/context/conf.js
@@ -40,6 +40,11 @@ if (IS_COVERAGE_ACTIVE) {
     configuration = JSON.parse(configurationString);
     Log.info('[Configuration] ', configuration);
   } catch (e) {
+    if (e instanceof SyntaxError) {
+      let errMsg = `Error: ${coverageFile} is not a valid JSON`;
+      console.error(errMsg, e);
+      Log.error(e.stack);
+    }
     // Set up defaultConfig value if they are not provided in the .coverage.json file
     Log.info('Loading default configuration');
     configuration = defaultConfig;


### PR DESCRIPTION
## Description

Warns user (through both, console and logger) when the customized `.coverage.json` is an invalid JSON (malformed, thus not parseable).

The PR only logs exception stack with `Log`. The console error only outputs an error warning about the invalid JSON and the excepcion message, which is descriptive enough to fix the problem without polluting the terminal.

Nevertheless, the package follows its normal flow, loading the default configuration from the package file `conf/default-coverage.json`.

## Motivation and Context

This is not a required change, but a very useful one. User can think the package is malfunctioning instead of realizing that he has made a mistake while writing the customized `.coverage.json`. It saves debugging time and false project issues, like #17, which I opened due to this.

## How Has This Been Tested?

Tested through terminal in Ubuntu Xenial Desktop 16.04, with :

- meteor@1.4.1.1
- lmieulet:meteor-coverage@0.9.4
- practicalmeteor:mocha@2.4.5_6
- spacejam: [https://github.com/serut/spacejam/tarball/windows-suppport-rc4](https://github.com/serut/spacejam/tarball/windows-suppport-rc4)

The PR should not affect other package parts, since it only checks for the type of the thrown exception and warns through console and logger if the customized `.coverage.json` file is an invalid JSON for the user to know.

## Screenshots (if appropriate):

No screenshoots, but an example of output in the terminal is:

```shell
W20160907-12:14:13.611(2)? (STDERR) Error: /home/user/meteor-app/.coverage.json is not a valid JSON [SyntaxError: Unexpected token }]
```

If need to reproduce, just create a dummy `.coverage.json` and place an extra comma after the last pair key/value in it, and run one of the following commands:

```shell
COVERAGE_VERBOSE=1 spacejam test-packages --driver-package practicalmeteor:mocha --coverage "out_html" packages/my-package
COVERAGE_VERBOSE=1 spacejam-mocha --coverage "out_html" packages/my-package
```

After applying this PR, you can omit the `COVERAGE_VERBOSE=1` part, as the problem is warned always if present.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

