### PR TITLE
Two new minimatch patterns for default meteor client side exclusions

### DIFF
--- a/conf/default-coverage.json
+++ b/conf/default-coverage.json
@@ -78,6 +78,8 @@
       "**/practicalmeteor_mocha-core.js",
       "**/kadira_flow-router.js",
       "**/tmeasday_test-reporter-helpers.js",
+      "**/coffeescript.js",
+      "**/lmieulet_meteor-coverage.js",
       "**/practicalmeteor_chai.js"
     ]
   },


### PR DESCRIPTION
Adds two new minimatch patterns to default meteor client side exclusions: `coffeescript.js` and `lmieulet_meteor-coverage.js`.
