### PR TITLE
Fix coverage verbosity

### DIFF
--- a/server/context/conf.js
+++ b/server/context/conf.js
@@ -8,6 +8,7 @@ const meteor_parameters = {
 };
 
 export const IS_COVERAGE_ACTIVE = meteor_parameters.IS_COVERAGE_ACTIVE === 1 ||  process.env['COVERAGE'] === '1';
+export const IS_COVERAGE_VERBOSE = Log.COVERAGE_VERBOSE;
 const ENV_NOT_DEFINED = '/SET/ENV/COVERAGE_APP_FOLDER/OR/READ/README/';
 
 export const COVERAGE_APP_FOLDER = meteor_parameters.COVERAGE_APP_FOLDER || process.env['COVERAGE_APP_FOLDER'] || ENV_NOT_DEFINED;
@@ -90,6 +91,7 @@ export const include = configuration.include;
 
 Log.info('Coverage configuration:');
 Log.info('- IS_COVERAGE_ACTIVE=', IS_COVERAGE_ACTIVE);
+Log.info('- IS_COVERAGE_VERBOSE=', IS_COVERAGE_VERBOSE);
 Log.info('- COVERAGE_APP_FOLDER=', COVERAGE_APP_FOLDER);
 Log.info('.coverage.json values:');
 Log.info('- exclude=', configuration.exclude);

--- a/server/context/log.js
+++ b/server/context/log.js
@@ -1,23 +1,22 @@
-export const COVERAGE_VERBOSE = process.env['COVERAGE_VERBOSE'] === '1' || false;
-
 export default Log = {
+  COVERAGE_VERBOSE: process.env['COVERAGE_VERBOSE'] === '1' || false,
   error: function() {
-    if (COVERAGE_VERBOSE) {
+    if (this.COVERAGE_VERBOSE) {
       console.error(...arguments);
     }
   },
   info: function() {
-    if (COVERAGE_VERBOSE) {
+    if (this.COVERAGE_VERBOSE) {
       console.log(...arguments);
     }
   },
   time: function() {
-    if (COVERAGE_VERBOSE) {
+    if (this.COVERAGE_VERBOSE) {
       console.log(...arguments);
     }
   },
   timeEnd: function() {
-    if (COVERAGE_VERBOSE) {
+    if (this.COVERAGE_VERBOSE) {
       console.log(...arguments);
     }
   }


### PR DESCRIPTION
## Description

The verbosity for coverage reports doesn't work because of undefined constants:

- The [default options for report generation](https://github.com/serut/meteor-coverage/blob/master/server/report/report-service.js#L17) use an undefined property `Log.COVERAGE_VERBOSE`. A constant `COVERAGE_VERBOSE` is exported in [`server/context/log.js`](https://github.com/serut/meteor-coverage/blob/master/server/context/log.js#L1), but it's not implemented as a property of `Log`. Since `Log` is a named export, this constant doesn't work like the others from `Conf`, and that's why that constant is `undefined` there.
- An undefined property `Conf.IS_COVERAGE_VERBOSE` is used when generating a [JSON summary report](https://github.com/serut/meteor-coverage/blob/master/server/report/report-json-summary.js#L11) and when getting options through [HTTP](https://github.com/serut/meteor-coverage/blob/master/server/report/report-http.js#L24).

## Motivation and Context

Get the coverage verbosity working.

## How Has This Been Tested?

I noticed it was not working when looking at the stdout output after executing `COVERAGE_VERBOSITY=1`.

You will see that the messages related to coverage report generation starting with `export coverage using the following format...` always report `verbose: false` before applying this PR.

Testing environment:

- Versions used:
   - meteor@1.4.1.1
   - lmieulet:meteor-coverage@0.9.4
   - practicalmeteor:mocha@2.4.5_6
   - spacejam: https://github.com/serut/spacejam/tarball/windows-suppport-rc4
- Environment name and version: Node.js v6.3.1
- Operating System and version: Ubuntu Xenial Desktop 16.04

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)