### PR TITLE
Remap to original sources

### DIFF
--- a/package.js
+++ b/package.js
@@ -33,7 +33,8 @@ Npm.depends({
   'istanbul-api': '1.1.0-alpha.1',
   'body-parser': '1.15.2',
   'minimatch': '3.0.3',
-  'mkdirp': '0.5.1'
+  'mkdirp': '0.5.1',
+  'remap-istanbul': '0.6.4'
 });
 
 Package.onTest(function (api) {

--- a/server/context/conf.js
+++ b/server/context/conf.js
@@ -82,11 +82,25 @@ if (IS_COVERAGE_ACTIVE) {
     Log.info('Loading default configuration: output');
     configuration.output = defaultConfig.output;
   }
+
+  // Source maps remapping
+  if (configuration && configuration.remap) {
+    if (typeof configuration.remap === "object") {
+      if (configuration.remap.format && configuration.remap.format.constructor !== Array) {
+        Log.error('Loading default configuration: remap.format is not an array', configuration.remap.format);
+        configuration['remap'] = null;
+      }
+    } else {
+      configuration['remap'] = null;
+      Log.error('Loading default configuration: remap is not an object', configuration.remap);
+    }
+  }
 }
 
 export const COVERAGE_EXPORT_FOLDER = configuration.output;
 export const exclude = configuration.exclude;
 export const include = configuration.include;
+export const remap = configuration.remap;
 
 Log.info('Coverage configuration:');
 Log.info('- IS_COVERAGE_ACTIVE=', IS_COVERAGE_ACTIVE);
@@ -94,4 +108,5 @@ Log.info('- COVERAGE_APP_FOLDER=', COVERAGE_APP_FOLDER);
 Log.info('.coverage.json values:');
 Log.info('- exclude=', configuration.exclude);
 Log.info('- include=', configuration.include);
+Log.info('- remap=', configuration.remap);
 Log.info('- COVERAGE_EXPORT_FOLDER=', COVERAGE_EXPORT_FOLDER);


### PR DESCRIPTION
## Description

This PR provides back remapping to original sources.

This let meteor developers using any language(s) that is compiled to JavaScript to get the coverage analysis referred to their original coded files.

The remap is done with [`remap-istanbul`](https://github.com/SitePen/remap-istanbul). I've added a new key to `.coverage.json` file. If user wants to get his/her source code remapped back to its originals, then s/he has to include the key `remap.format` in his/her `.coverage.json`.

The value for this key is a string array with the desired following report types: `html`, `clover`, `cobertura`, `teamcity`, `text-summary`, `text`, `lcovonly`, `json-summary`, `json`.

Some comments about this PR:

- The remapped coverage is saved into `${COVERAGE_EXPORT_FOLDER}-remap` folder, to not overwrite the original output of this package (corresponding to the compiled JavaScript).
- Although the `text`/`clover`/`cobertura` report types are not implemented per se yet, `remap-istanbul` converts an input JSON into any of the previous types, so that is not a limitation here, and you can get those report types with this feature.
- Because of `remap-istanbul` requires a JSON as input, the user is required to request the report type `out_json_report` to feed the conversion through the command line like this: `spacejam-mocha ./ --coverage out_json_report`. If user requests other report type(s) than `out_json_report`, it doesn't matter what he states in the `.coverage.json` file: it gets ignored.
- The remap output folder is automatically created, so user doesn't have to worry about that.
- This can be used to get coverage feedback right in the Atom IDE (with the [`lcov-info`](https://atom.io/packages/lcov-info) package, for example). For that package, you just have to create a folder `coverage` and then symlink with `ln -sf .coverage-remap/lcov.info coverage/lcov.info`. Obviously, you must request `lcovonly` with `remap.format` in `.coverage.json` to get that report file.
- I've used the key `remap.format` because `remap-istanbul` can receive other params which I've not implemented with this PR. In the future, if these params are implemented, they only need to use a different subkey in `remap`, so this will not introduce a breaking change.
- I've tested this PR only with TypeScript and Atom, so don't ask me for other IDEs or languages (like CoffeeScript and similar). Nevertheless, this should work because it uses the source maps, so it is not limited to a given language. If you want to test your language/IDE, your feedback is welcome.

This was the goal I was in mind when started using this package, so I hope others benefit from it so much as I'm going to :grin: 

## Motivation and Context

This new feature is required because checking the coverage details over compiled JavaScript is a headache. We use languages like TypeScript to improve readability and typing, and all of this get lost in the compiled JavaScript.

This PR uses the source maps generated by the compiler to map info of the coverage reports again to the original source file.

## How Has This Been Tested?

Testing environment:

- Versions used:
   - meteor@1.4.1.1
   - lmieulet:meteor-coverage@0.9.4
   - practicalmeteor:mocha@2.4.5_6
   - spacejam: https://github.com/serut/spacejam/tarball/windows-suppport-rc4
   - typescript@1.8.9
- Environment name and version: Node.js v6.3.1
- Operating System and version: Ubuntu Xenial Desktop 16.04

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)