### PR TITLE
Fix SourceMap sources paths

### DIFF
--- a/package.js
+++ b/package.js
@@ -32,6 +32,7 @@ Package.onUse(function (api) {
 Npm.depends({
   'istanbul-api': '1.1.0-alpha.1',
   'body-parser': '1.15.2',
+  'homedir': '0.6.0',
   'minimatch': '3.0.3',
   'mkdirp': '0.5.1'
 });

--- a/server/boot.js
+++ b/server/boot.js
@@ -4,6 +4,7 @@ import mkdirp from 'mkdirp';
 import Conf from './context/conf';
 import Router from './router';
 import Instrumenter from './services/instrumenter';
+import SourceMap from './services/source-map';
 
 export default Boot = {
   startup() {
@@ -19,6 +20,8 @@ export default Boot = {
         }
       }
     });
+    // Search for PUTs and check whether called from inside/outside a PUT dir
+    SourceMap.initialSetup();
     // Start to collect coverage
     Instrumenter.hookLoader();
     // Connect the router to this app

--- a/server/services/source-map.js
+++ b/server/services/source-map.js
@@ -3,92 +3,220 @@ import Conf from './../context/conf';
 import fs from 'fs';
 import path from 'path';
 
+const homedir = Npm.require('homedir');
 const istanbulAPI = Npm.require('istanbul-api');
 const libSourceMaps = istanbulAPI.libSourceMaps;
 
 const sourceMap = libSourceMaps.createSourceMapStore({verbose: Conf.IS_COVERAGE_ACTIVE});
-const meteor_dir = Conf.COVERAGE_APP_FOLDER;
-// Next RegExps must consider following paths:
-//  1. meteor://💻app/packages/lmieulet:meteor-coverage/server/index.js
-//  2. meteor://💻app/.npm/package/node_modules/minimatch/package.json
-//  3. meteor://💻app/node_modules/meteor/lmieulet:meteor-coverage/node_modules/minimatch/minimatch.js
-//  4. meteor://💻app/packages/local-test:lmieulet:meteor-coverage/server/tests.js
-//  5. meteor://💻app/node_modules/meteor/local-test:cgalvarez:my-package/tests/client/mocks.js
-//  6. meteor://💻app/node_modules/meteor/local-test:cgalvarez:my-package/node_modules/chai-as-promised/lib/chai-as-promised.js
-const regexAlterationSourceMapPath = new RegExp(/^(packages\/|node_modules\/meteor\/)(?:local-test[_:])?([a-zA-Z-]*)[_:]([a-zA-Z-_]*)(.*)$/);
-const regexPUT = new RegExp(/packages\/local-test:([a-zA-Z-_]*):([a-zA-Z-_]*)\/.*/);
+const meteorDir = Conf.COVERAGE_APP_FOLDER;
+const splitToken = String.fromCharCode(56507) + 'app/'; // caution! magic character inside the SourceMap source(s) path
+
+const abspath = {
+  local: path.join(__meteor_bootstrap__.serverDir, '..', '..', '..'), // could use process.env.METEOR_SHELL_DIR too
+  currentBuild: path.join(__meteor_bootstrap__.serverDir, '..'),
+  serverSide: __meteor_bootstrap__.serverDir,
+  clientSide: path.join(__meteor_bootstrap__.serverDir, '..', 'web.browser'),
+  // Meteor packages folder can be overriden with the env var PACKAGE_DIRS, otherwise
+  // '$HOME/.meteor/packages'. Take a look at https://dweldon.silvrback.com/local-packages
+  // or https://github.com/meteor/meteor/blob/devel/History.md#v040-2012-aug-30
+  packages: process.env.PACKAGE_DIRS || path.join(homedir(), '.meteor', 'packages')
+};
+const rgx = {
+  meteorPackageMergedFile: /^\/packages\/(local-test_)?(?:([^\/_]+)_)?([^\/_]+).js$/,
+  meteorPackagePathTokens: /^(?:packages\/|node_modules\/meteor\/)(?:local-test[_:])?([^_:\/]+[_:])?([^_:\/]+)\/(node_modules\/)?(.*)$/,
+  meteorPUT: /^local-test:([^_:\/]+:[^_:\/]+)$/,
+  packageJson: /^(?:\.npm\/package\/node_modules\/(.*)|\.\.\/npm\/node_modules\/(.*))$/
+};
+
+isAccessible = function(path, mode = fs.R_OK, supressErrors = false) {
+  try {
+    fs.accessSync(path, mode);
+    return true;
+  } catch (e) {
+    !supressErrors && Log.error('Cannot access ', path);
+    return false;
+  }
+}
+parseJSON = function(filePath, supressAccessErrors = false) {
+  if (isAccessible(filePath, fs.R_OK, supressAccessErrors)) {
+    try {
+      return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    } catch(e) {
+      Log.Error('Invalid JSON: ', filePath, e);
+    }
+  }
+}
+
+initialSetup = function () {
+  // Get the resolved, compiled and used packages and their versions
+  let resolverResultPath = path.join(abspath.local, 'resolver-result-cache.json');
+  let resolverResult = parseJSON(resolverResultPath);
+  this.resolved = resolverResult ? resolverResult.lastOutput.answer : null;
+
+  if (Meteor.isPackageTest && this.resolved) {
+    // Find the package(s) under test (PUT)
+    for (let pkg in this.resolved) {
+      let match = rgx.meteorPUT.exec(pkg);
+      match && (this.PUT[match[1]] = true);
+    }
+    const PUTs = Object.keys(this.PUT);
+    if (PUTs.length) {
+      Log.info(`Packages under test (${PUTs.length}):`, PUTs.join(', '));
+    } else {
+      Log.error('No packages under test in test-packages mode');
+    }
+
+    // Check if testing from inside (package-dir) or outside (meteor-app-dir)
+    // We only need to check ONE test file, but we must consider that all PUTs
+    // maybe client-side or server-side, so we should check both and exit on first match
+    const sidePaths = {
+      load: abspath.serverSide,
+      manifest: abspath.clientSide
+    };
+    for (let key in sidePaths) {
+      const programPath = path.join(sidePaths[key], 'program.json');
+      const program = parseJSON(programPath);
+      if (!program) continue;
+
+      for (let file of program[key]) {
+        if (file.path.startsWith('packages/local-test_')) { // meteor package test(s) merged file
+          const sourceMapPath = path.join(sidePaths[key], file.sourceMap);
+          const sourceMap = parseJSON(sourceMapPath);
+          if (!sourceMap) continue;
+
+          // A compiled test file (local-test_...) has only the declared test
+          // files inside `package.js` as its sources, so check the first one
+          this.testingFromPackageDir = true;
+          let filepathToCheck = fixSourcePath.call(this, sourceMap.sources[0], null, meteorDir);
+          if (!isAccessible(filepathToCheck, fs.R_OK, true)) {
+            this.testingFromPackageDir = false;
+          }
+          break;
+        }
+      }
+      if (this.testingFromPackageDir !== undefined) break;
+    }
+    if (this.testingFromPackageDir === undefined) {
+      Log.error('User running test-packages without tests');
+    }
+  }
+}
 
 // Alter inside the source map the path of each sources
-alterSourceMapPaths = function (map) {
-  var match;
-  if (!this.PUT && Meteor.isPackageTest && meteor_dir === `${process.env.PWD}/`) {
-    // Search for the author and name of the PUT (Package Under Test)
-    // and save it in Meteor object to be accessible later on
-    for (let i = 0; i < map.sources.length; i++) {
-      if (regexPUT.test(map.sources[i])) {
-        let pkgAuthor, pkgName;
-        [, pkgAuthor, pkgName] = regexPUT.exec(map.sources[i]);
-        if (!this.PUT) {
-          this.PUT = {
-            author: pkgAuthor,
-            name: pkgName
-          };
+_alterSourceMapPaths = function (map, isClientSide) {
+  // Absolute path to sources of a Meteor package. PUTs are treated differently than normal because they
+  // might not exist at abspath.packages, so PUT packages always are resolved depending on
+  // COVERAGE_APP_FOLDER and whether `meteor test-packages` was executed from inside/outside the package
+  // folder. Sources base of any Meteor packages not under test is always resolved to abspath.packages
+  let sourcesBase, isTestFile, matchAuthor, matchName;
+  if (rgx.meteorPackageMergedFile.test(map.file)) {
+    [, isTestFile, matchAuthor, matchName] = rgx.meteorPackageMergedFile.exec(map.file);
+    const packageID = matchAuthor ? `${matchAuthor}:${matchName}` : matchName;
+    if (Meteor.isPackageTest && (!!isTestFile || this.PUT[packageID])) {
+      sourcesBase = this.testingFromPackageDir ? meteorDir : path.join(meteorDir, 'packages', matchName);
+    } else if (this.resolved[packageID]) {
+      const packageFolder = matchAuthor ? `${matchAuthor}_${matchName}` : matchName;
+      sourcesBase = path.join(abspath.packages, packageFolder, this.resolved[packageID], 'web.browser');
+    }
+  }
+
+  // Get `node_modules` base path for this map.file
+  let nodeModulesBase, program = parseJSON(path.join(abspath.serverSide, 'program.json'));
+  if (!isClientSide && program) {
+    // Find the item matching map.file path
+    const mergedPath = map.file.substr(1);
+    for (let file of program.load) {
+      if (file.path === mergedPath) {
+        if (file.node_modules) {
+          nodeModulesBase = path.join(abspath.serverSide, file.node_modules);
+          nodeModulesBase = fs.realpathSync(nodeModulesBase); // usually a symlink
         }
         break;
       }
     }
   }
+  if (!nodeModulesBase && sourcesBase) {
+    // Try locating node_modules inside sourcesBase sibling `npm`
+    let sourcesSiblingFolder = path.join(sourcesBase, '..', 'npm', 'node_modules');
+    if (isAccessible(sourcesSiblingFolder, fs.R_OK, true)) {
+      nodeModulesBase = sourcesSiblingFolder;
+    }
+  }
 
-  const npmPkgFolder = 'node_modules';
-  const npmPkgDepPrefix = `${npmPkgFolder}/meteor/`;
-  const splitToken = String.fromCharCode(56507) + 'app/';
-  for (var i = 0; i < map.sources.length; i++) {
-    // Magic character inside the path
-    var paths = map.sources[i].split(splitToken);
-    if (paths.length === 2) {
-      let matchAuthor, matchName, matchPath;
-      // if it's a package the path is wrong
-      match = regexAlterationSourceMapPath.exec(paths[1]);
-      if (match) {
-        matchAuthor = match[3];
-        matchName = match[4];
-        matchPath = match[5];
-        // Imported NPM dependency
-        // Custom user file imported in test file or package loaded for app or meteor framework
-        if (this.PUT && matchAuthor === this.PUT.author && matchName === this.PUT.name && matchPath && match[1] === npmPkgDepPrefix && matchPath.startsWith(npmPkgFolder, 1)) {
-          map.sources[i] = path.join(meteor_dir, '.npm/package', matchPath);
-          // the continue statement breaks one iteration of the loop
-          continue;
-        }
-      }
-      if (matchPath) {
-        map.sources[i] = path.join(meteor_dir,  matchPath);
-      } else {
-        map.sources[i] = path.join(meteor_dir, paths[1]);
-      }
+  // Fix sources paths, but be aware that, although you might be tempted to remove items
+  // from map.{sources|contentSources} (like non-instrumentable files: *.css, *.json,...),
+  // you must NOT do it, because their indexes are still being used by the mappings and
+  // you'll get a sound `Error('No element indexed by {index}')`.
+  for (let i = 0; i < map.sources.length; i++) {
+    let fixed = fixSourcePath.call(this, map.sources[i], nodeModulesBase, sourcesBase);
+
+    if (map.sources[i] === fixed) {
+      Log.error('Source could not be altered:', map.sources[i]);
+    } else if (isAccessible(fixed)) {
+      map.sources[i] = fixed;
     } else {
-      Log.error('Failed to alter source map path', map.sources[i]);
+      Log.error('Altered source could not be accessed:', map.sources[i]);
     }
   }
   return map;
 };
 
-registerSourceMap = function (filepath) {
-  // SIDE EFFECTS
-  Log.time('registerSourceMap' + filepath);
-  sourceMapPath = filepath + '.map';
-  if (fs.existsSync(sourceMapPath)) {
-    fileContent = JSON.parse(fs.readFileSync(sourceMapPath, 'utf8'));
-    fileContent = alterSourceMapPaths(fileContent);
-    Log.info('Add source map for file ' + sourceMapPath);
+// Fixes path of a source (file) in the SourceMap of a concatenated Meteor package test file
+fixSourcePath = function(source, nodeModulesBase, sourcesBase) {
+  let match, paths = source.split(splitToken).slice(1);
+
+  // Skip sources with unknown syntax
+  if (!paths.length) {
+    Log.error('Source with unknown format:', source);
+    return source;
+  }
+
+  // The source is the package.json of a NPM dependency. Catches all next patterns:
+  //  1. meteor://💻app/.npm/package/node_modules/minimatch/package.json
+  //  2. meteor://💻app/../npm/node_modules/meteor-babel-helpers/package.json
+  match = rgx.packageJson.exec(paths[0]);
+  if (match) {
+    return match[1] ? path.join(nodeModulesBase, match[1]) : path.join(sourcesBase, paths[0]);
+  }
+
+  // The source is a Meteor package file (NPM dep or own file). Catches all next patterns:
+  //  3. meteor://💻app/packages/lmieulet:meteor-coverage/server/index.js
+  //  4. meteor://💻app/packages/local-test:lmieulet:meteor-coverage/server/tests.js
+  //  5. meteor://💻app/node_modules/meteor/lmieulet:meteor-coverage/node_modules/minimatch/minimatch.js
+  //  6. meteor://💻app/node_modules/meteor/local-test:cgalvarez:my-package/tests/client/mocks.js
+  //  7. meteor://💻app/node_modules/meteor/local-test:cgalvarez:my-package/node_modules/chai-as-promised/lib/chai-as-promised.js
+  let matchAuthor, matchName, isNpmDep, matchPath;
+  match = rgx.meteorPackagePathTokens.exec(paths[0]);
+  if (match) {
+    [, matchAuthor, matchName, isNpmDep, matchPath] = match;
+    return path.join(isNpmDep ? nodeModulesBase : sourcesBase, matchPath);
+  }
+
+  // Meteor app file
+  return path.join(meteorDir, paths[0]);
+};
+
+// Processes the source map (when exists) of an instrumented file to fix broken sources paths
+registerSourceMap = function(filepath) {
+  Log.time('START registerSourceMap', filepath);
+  const sourceMapPath = filepath + '.map';
+  let fileContent = parseJSON(sourceMapPath, true);
+  if (fileContent) {
+    fileContent = _alterSourceMapPaths.call(this, fileContent,
+      filepath.startsWith('../web.browser/') || filepath.startsWith(abspath.clientSide));
+    Log.info('Add source map for file', sourceMapPath);
     sourceMap.registerMap(filepath, fileContent);
   } else {
-    Log.error('Source map not found', sourceMapPath);
+    Log.info('Source map not found', sourceMapPath);
   }
-  Log.timeEnd('registerSourceMap' + filepath);
+  Log.timeEnd('END registerSourceMap', filepath);
 };
+
 export default SourceMap = {
+  initialSetup,
   lib: sourceMap,
-  PUT: {},
-  registerSourceMap
+  PUT: {},                          // Meteor package(s) under test
+  registerSourceMap,
+  resolved: undefined,              // Meteor packages in use and their version
+  testingFromPackageDir: undefined  // Whether `meteor test-packages` is run from inside/outside the package dir
 };


### PR DESCRIPTION
## Description

I decided grabbing the bull by its horns and instrumented ALL files to finally fix SourceMap sources paths. The final result is this PR. These are the most significative changes:

- Getting the package(s) under test (when run in `test-packages` mode) and checking whether executing from inside/outside a package folder is done only once at startup (boot).
- The new algorithm is heavily based on the build files auto-generated by Meteor and thus it's more accurate than previous.
- Removed `fs.existsSync()` calls since it's deprecated and replaced them with `fs.accessSync()` instead.
- Created some helper functions (`isAccessible()`, `parseJSON`) that refactor code of common actions and improve code readability.
- Fixed an issue with context when calling `alterSourceMapPaths()` from `SourceMap.registerSourceMap()` which causes `SourceMap` properties to be unavailable sometimes (`undefined`).
- Now source code is more readable and easier to understand.
- Removed environment variables (`process.env.PWD`) not related to or set by Meteor.
- Now the user is warned when `COVERAGE_VERBOSE=1` and any source in a SourceMap cannot be accessed or resolved, so they can provide useful logs if any future issue.
- The source patterns are now easily tracked in the code, including the new one found.
- Changed type of message thrown when no source map found from error to info (non-existent source map should not be treated as an error).

## Motivation and Context

This PR closes previous PR #22 and issue #21 .

The previous PR was more difficult to understand and trace.

## How Has This Been Tested?

Tested with `meteor test-packages ./ --driver-package practicalmeteor:mocha --settings settings.coverage.json`, run inside a clone of the branch `dev-1.0.0` of this package.

My development/testing environment:

- Versions used:
   - meteor@1.4.1.1
   - lmieulet:meteor-coverage@dev-1.0.0
   - practicalmeteor:mocha@2.4.5_6
- Environment name and version: Node.js v6.3.1
- Operating System and version: Ubuntu Xenial Desktop 16.04

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)