### PR TITLE
Fix remap @ dev-1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # meteor-coverage
 
-A meteor package that allows you to get the statement, line, function and branch coverage of Meteor project and package.  
-This package uses the [istanbuljs/istanbul-api](https://github.com/istanbuljs/istanbul-api) package for coverage report.  
+A meteor package that allows you to get the statement, line, function and branch coverage of Meteor project and package.
+
+This package uses the [istanbuljs/istanbul-api](https://github.com/istanbuljs/istanbul-api) package for coverage report.
+
 It's a debug only package, so it does not affect your production build.
 
 ## CI Platforms supported
@@ -119,7 +121,7 @@ Add what you need to run your app inside your `package.json`:
 If you want to, you can use this syntax, the following two commands are equivalent, but the second one is shorter and thus less typing error-prone
 
     spacejam       [..] --driver-package practicalmeteor:mocha-console-runner 
-    spacejam-mocha [..]"
+    spacejam-mocha [..]
     
 Same for meteor:
 
@@ -170,6 +172,7 @@ Add this after tests execution:
 -   `out_json_report` creates a json report
 -   `out_json_summary` creates a json_summary report
 -   `out_text_summary` creates a text_summary report
+-   `out_remap` remaps the coverage to all the available report formats
 -   `out_teamcity` & `out_clover` are not working yet
 
 ## Meteor --settings file
@@ -189,7 +192,7 @@ Create the `settings.coverage.json` file with the following:
 }
 ```
 
-Note that `coverage_app_folder : /path/to/your/meteor/app/` requires to end with a trailing slash
+Note that `coverage_app_folder : /path/to/your/meteor/app/` requires to end with a trailing slash.
 
 
 
@@ -281,11 +284,11 @@ If you have **internal packages** inside your app and you want to get their **se
 
 ## Ignore code from coverage with annotation
 
-For example, if you code an `if` block without `else`, istanbul marks the `else` branch as not covered (although it doesn't exist), decreasing your code coverage, which is **false**.  
-Same issue with ternary operator (`expression ? value1 : value2`) or default assignments (like `let myVar = otherVar || {}`), which always get marked as uncovered branches.  
+For example, if you code an `if` block without `else`, istanbul marks the `else` branch as not covered (although it doesn't exist), decreasing your code coverage, which is **false**.
 
-The syntax can be found there:  
-https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md
+Same issue with ternary operator (`expression ? value1 : value2`) or default assignments (like `let myVar = otherVar || {}`), which always get marked as uncovered branches.
+
+The syntax can be found at [istanbul docs - ignoring code](https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md).
 
 ## Meteor ignored folders and files
 
@@ -297,6 +300,47 @@ https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md
 ## How to replace spacejam
 
 You can find [here](https://github.com/practicalmeteor/spacejam/compare/windows-suppport...serut:windows-suppport-rc4?diff=split&name=windows-suppport-rc4#diff-f388d8f4ed9765929079f40166396fdeR65) the diff between "spacejam without coverage" and "spacejam coverage", so you can build something else,  with grunt for example, that exports your test.
+
+## I want my reports referred to my original source files
+
+If you are using a language that compiles to JavaScript (there are [lots of them](https://github.com/jashkenas/coffeescript/wiki/list-of-languages-that-compile-to-js)), you may want to see your coverage reports referred to the original source files (prior to compilation).
+
+To remap your source files, you have to provide the report type `out_remap` explicitly when using `spacejam`:
+
+```shell
+spacejam test-packages --driver-package practicalmeteor:mocha --coverage out_remap
+spacejam-mocha --coverage out_remap
+```
+
+You'll get your remapped coverage reports at `./.coverage/.remap` (or `custom_output/.remap` if you're customized the output folder through the file `.coverage.json`).
+
+The coverage is remapped to **all the available reports** (listed in the following example) by default. If you only want some of them, you need to request them explicitly through the key `remap.format` in `.coverage.json` like this:
+
+```json
+{
+  "include": [
+    "**/packages/lmieulet_meteor-coverage.js"
+  ],
+  "remap": {
+    "format": ["html", "clover", "cobertura", "json", "json-summary", "lcovonly", "teamcity", "text", "text-summary"]
+  }
+}
+```
+
+If you want to remap the coverage with `Meteor.exportCoverage()`, then you must use the report type `remap`.
+
+This feature has only been tested with TypeScript, but it should work for any language compiled to JavaScript, just **make sure you generate source maps (\*.js.map) for all the compiled files and that source maps are located next to their respective compiled JavaScript file (\*.js)**, just like this:
+
+```
+COVERAGE_APP_FOLDER
+├── tsconfig.json
+├── src
+|   ├── my-file.ts
+|   └── my-file.d.ts
+├── build
+|   ├── my-file.js
+|   └── my-file.js.map
+```
 
 -----------
 
@@ -351,8 +395,10 @@ Anyone is welcome to contribute.
 ## Credits
 
 This package would not exist without the amazing work of:
+
 -   [Contributors](https://github.com/serut/meteor-coverage/graphs/contributors) and testers for their help
 -   [Xolv.io](http://xolv.io) and their work on the original [meteor-coverage](https://github.com/xolvio/meteor-coverage) package;
 -   All contributors of [istanbul-api](https://github.com/istanbuljs/istanbul-api) and [istanbul-middleware](https://github.com/gotwarlost/istanbul-middleware) projects.
 
 All of them were very helpful in the development of this package. Merci !  
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+#### 1.0.0
+
+-   add warning when `.coverage.json` is an invalid JSON
+-   move some tasks to boot class
+-   fix verbosity ignored on report generation
+-   fix source map paths mapping them to real paths
+-   improved glob patterns in `.coverage.json`
+-   add new type of export `remap` that adds support to languages that compile to JavaScript (like TypeScript)
+
 #### 0.9.4
 
 -   The configuration file `.coverage.json` is now written in minimatch syntax instead of regex

--- a/client/methods.e2e.tests.js
+++ b/client/methods.e2e.tests.js
@@ -1,6 +1,22 @@
 import {assert} from 'meteor/practicalmeteor:chai';
 import Meteor from 'meteor/lmieulet:meteor-coverage';
-describe('meteor-coverage', function (done) {
+
+var testCoverage = function(done, operation, reportType) {
+  this.timeout(0);
+  try {
+    let params = operation === 'export' ? [reportType] : [];
+    params.push(function (err) {
+      assert.isUndefined(err);
+      done();
+    });
+    Meteor[`${operation}Coverage`].apply(this, params);
+  } catch (e) {
+    console.error(e, e.stack);
+    done(e);
+  }
+};
+
+describe('meteor-coverage', function () {
 
   it('send client coverage', function (done) {
     this.timeout(10000);
@@ -19,146 +35,17 @@ describe('meteor-coverage', function (done) {
     }
   });
 
-  it('export coverage', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.exportCoverage(
-        'coverage',
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
+  let coverage = {
+    export: ['coverage', 'lcovonly', 'json', 'json-summary', 'text-summary', 'html', 'remap'],
+    import: ['coverage']
+  };
+  for (let operation in coverage) {
+    if (coverage.hasOwnProperty(operation)) {
+      coverage[operation].forEach(function (reportType) {
+        it(`${operation} ${reportType}`, function (done) {
+          testCoverage.call(this, done, operation, reportType); // pass mocha context
+        });
+      });
     }
-  });
-
-  it('import coverage', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.importCoverage(
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-  });
-
-  it('export lcovonly', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.exportCoverage(
-        'lcovonly',
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-  });
-
-  it('export json', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.exportCoverage(
-        'json',
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-  });
-
-  it('export json-summary', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.exportCoverage(
-        'json-summary',
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-  });
-
-  it('export text-summary', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.exportCoverage(
-        'text-summary',
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-  });
-
-  it('export html', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.exportCoverage(
-        'html',
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-  });
-
-  it('export remap', function (done) {
-    this.timeout(0);
-    try {
-      Meteor.exportCoverage(
-        'remap',
-        function (err) {
-          assert.isUndefined(err);
-          done();
-        }
-      );
-
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-  });
-  /*
-   // not working
-   it('export teamcity', function (done) {
-   this.timeout(10000);
-
-   Meteor.exportCoverage(
-   'teamcity',
-   function(err) {
-   assert.isUndefined(err);
-   done();
-   }
-   );
-   });*/
+  }
 });

--- a/conf/default-coverage.json
+++ b/conf/default-coverage.json
@@ -28,5 +28,6 @@
       "**/?(*.)app-spec?(s).?*"
     ]
   },
+  "remapFormat": ["html", "cobertura", "clover", "json", "json-summary", "lcovonly", "teamcity", "text", "text-summary"],
   "output": "./.coverage"
 }

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'lmieulet:meteor-coverage',
-  version: '0.9.6',
+  version: '1.0.0',
   summary: 'Server and client coverage for Meteor',
   git: 'https://github.com/serut/meteor-coverage',
   documentation: 'README.md',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-coverage",
-  "version": "0.9.6",
+  "version": "1.0.0",
   "description": "A meteor package that allows you to get the statement, line, function and branch coverage of Meteor project and package.   This package uses the [istanbuljs/istanbul-api](https://github.com/istanbuljs/istanbul-api) package for coverage report.   It's a debug only package, so it does not affect your production build.",
   "main": "server/index.js",
   "dependencies": {

--- a/server/context/conf.js
+++ b/server/context/conf.js
@@ -13,6 +13,7 @@ const ENV_NOT_DEFINED = '/SET/ENV/COVERAGE_APP_FOLDER/OR/READ/README/';
 
 export const COVERAGE_APP_FOLDER = meteor_parameters.COVERAGE_APP_FOLDER || process.env['COVERAGE_APP_FOLDER'] || ENV_NOT_DEFINED;
 
+/* istanbul ignore else */
 if (COVERAGE_APP_FOLDER === ENV_NOT_DEFINED) {
   Log.error('Error: COVERAGE_APP_FOLDER is undefined and the coverage will fail.');
 }
@@ -26,6 +27,7 @@ let configuration = {
   include: [],
   output: NOT_DEFINED
 };
+/* istanbul ignore else */
 if (IS_COVERAGE_ACTIVE) {
   const fs = Npm.require('fs'),
     path = Npm.require('path');
@@ -54,36 +56,43 @@ if (IS_COVERAGE_ACTIVE) {
   // Don't force to rewrite all the key of configuration.exclude,
   // if they are not defined, the default conf is used.
 
+  /* istanbul ignore else */
   if (configuration.exclude === undefined) {
     Log.info('Loading default configuration: exclude.*');
     configuration.exclude = defaultConfig.exclude;
   }
 
+  /* istanbul ignore else */
   if (configuration.exclude.general === undefined) {
     Log.info('Loading default configuration: exclude.general');
     configuration.exclude.general = defaultConfig.exclude.general;
   }
 
+  /* istanbul ignore else */
   if (configuration.exclude.server === undefined) {
     Log.info('Loading default configuration: exclude.server');
     configuration.exclude.server = defaultConfig.exclude.server;
   }
 
+  /* istanbul ignore else */
   if (configuration.exclude.client === undefined) {
     Log.info('Loading default configuration: exclude.client');
     configuration.exclude.client = defaultConfig.exclude.client;
   }
 
+  /* istanbul ignore else */
   if (configuration.include === undefined) {
     Log.info('Loading default configuration: include');
     configuration.include = defaultConfig.include || [];
   }
 
+  /* istanbul ignore else */
   if (configuration.output === undefined) {
     Log.info('Loading default configuration: output');
     configuration.output = defaultConfig.output;
   }
 
+  /* istanbul ignore else */
   if (configuration.remapFormat === undefined) {
     Log.info('Loading default configuration: remapFormat');
     configuration.remapFormat = defaultConfig.remapFormat;
@@ -102,5 +111,5 @@ Log.info('- COVERAGE_APP_FOLDER=', COVERAGE_APP_FOLDER);
 Log.info('.coverage.json values:');
 Log.info('- exclude=', configuration.exclude);
 Log.info('- include=', configuration.include);
-Log.info('- remapFormat=', configuration.remap);
+Log.info('- remapFormat=', configuration.remapFormat);
 Log.info('- COVERAGE_EXPORT_FOLDER=', COVERAGE_EXPORT_FOLDER);

--- a/server/context/conf.js
+++ b/server/context/conf.js
@@ -85,16 +85,21 @@ if (IS_COVERAGE_ACTIVE) {
   }
 
   // Source maps remapping
+  let defFormats = ['html', 'cobertura', 'clover', 'json', 'json-summary', 'lcovonly', 'teamcity', 'text', 'text-summary'];
   if (configuration && configuration.remap) {
     if (typeof configuration.remap === 'object') {
       if (configuration.remap.format && configuration.remap.format.constructor !== Array) {
         Log.error('Loading default configuration: remap.format is not an array', configuration.remap.format);
-        configuration['remap'] = null;
+        configuration.remap = null;
       }
     } else {
-      configuration['remap'] = null;
+      configuration.remap = null;
       Log.error('Loading default configuration: remap is not an object', configuration.remap);
     }
+  }
+  // Assign a default value (generate all available formats) if not provided
+  if (!configuration.remap) {
+    configuration.remap = {format: defFormats};
   }
 }
 

--- a/server/context/conf.js
+++ b/server/context/conf.js
@@ -84,29 +84,16 @@ if (IS_COVERAGE_ACTIVE) {
     configuration.output = defaultConfig.output;
   }
 
-  // Source maps remapping
-  let defFormats = ['html', 'cobertura', 'clover', 'json', 'json-summary', 'lcovonly', 'teamcity', 'text', 'text-summary'];
-  if (configuration && configuration.remap) {
-    if (typeof configuration.remap === 'object') {
-      if (configuration.remap.format && configuration.remap.format.constructor !== Array) {
-        Log.error('Loading default configuration: remap.format is not an array', configuration.remap.format);
-        configuration.remap = null;
-      }
-    } else {
-      configuration.remap = null;
-      Log.error('Loading default configuration: remap is not an object', configuration.remap);
-    }
-  }
-  // Assign a default value (generate all available formats) if not provided
-  if (!configuration.remap) {
-    configuration.remap = {format: defFormats};
+  if (configuration.remapFormat === undefined) {
+    Log.info('Loading default configuration: remapFormat');
+    configuration.remapFormat = defaultConfig.remapFormat;
   }
 }
 
 export const COVERAGE_EXPORT_FOLDER = configuration.output;
 export const exclude = configuration.exclude;
 export const include = configuration.include;
-export const remap = configuration.remap;
+export const remapFormat = configuration.remapFormat;
 
 Log.info('Coverage configuration:');
 Log.info('- IS_COVERAGE_ACTIVE=', IS_COVERAGE_ACTIVE);
@@ -115,5 +102,5 @@ Log.info('- COVERAGE_APP_FOLDER=', COVERAGE_APP_FOLDER);
 Log.info('.coverage.json values:');
 Log.info('- exclude=', configuration.exclude);
 Log.info('- include=', configuration.include);
-Log.info('- remap=', configuration.remap);
+Log.info('- remapFormat=', configuration.remap);
 Log.info('- COVERAGE_EXPORT_FOLDER=', COVERAGE_EXPORT_FOLDER);

--- a/server/report/report-remap.js
+++ b/server/report/report-remap.js
@@ -66,7 +66,7 @@ export default class {
     let sourceStore = new MemoryStore();
     let collector = remapIstanbul.remap(remapIstanbul.loadCoverage(sources), {
       sources: sourceStore,
-      warn: Log.info
+      warn: function() {}
     });
 
     /* istanbul ignore else */

--- a/server/report/report-service.js
+++ b/server/report/report-service.js
@@ -1,3 +1,5 @@
+import Log from './../context/log';
+import Conf from './../context/conf';
 import IstanbulGenericReporter from './report-generic';
 import JsonSummary from './report-json-summary';
 import Teamcity from './report-teamcity';
@@ -5,9 +7,7 @@ import Html from './report-html';
 import Http from './report-http';
 import ReportCoverage from './report-coverage';
 import ReportRemap from './report-remap';
-import Log from './../context/log';
 import TextSummary from './report-text-summary';
-import Conf from './../context/conf';
 import path from 'path';
 
 export default class {
@@ -23,8 +23,8 @@ export default class {
       switch (type) {
       case 'remap':
         {
-          let reportRemap = new ReportRemap(res, type, options);
-          Conf.remap && reportRemap.generate();
+          let reportRemap = new ReportRemap(res, type, options, Log);
+          reportRemap.generate();
           break;
         }
       case 'lcovonly':

--- a/server/report/report-service.js
+++ b/server/report/report-service.js
@@ -23,7 +23,7 @@ export default class {
       switch (type) {
       case 'remap':
         {
-          let reportRemap = new ReportRemap(res, type, options, Log);
+          let reportRemap = new ReportRemap(res, type, options);
           reportRemap.generate();
           break;
         }


### PR DESCRIPTION
## Description

- [x] Fix remap timeout or replace `it` by `xit` to ignore the test
- [x] Edit readme.md with how to use remap
- [x] Remove legacy code inside reporters because now files  are merged correctly mapped with real ones 
- [x] Edit changelog
- [x] Update version in `package.js` and `package.json`
- [x] meteor-coverage-app-exemple build ok : [![Build Status](https://travis-ci.org/serut/meteor-coverage-app-exemple.svg?branch=master)](https://travis-ci.org/serut/meteor-coverage-app-exemple) 👋 
- [x] Remove annoying messages printed with `console.error()` by `remap-istanbul` when writing files of HTML report (printed as errors, but they are not; printed [here](https://github.com/gotwarlost/istanbul/blob/master/lib/report/html.js#L478-L487)).
- [ ] Issue with `console.log` and `Log.info`
- [ ] Improve coverage

### Steps to reproduce issue with `console.log` and `Log.info`

1. Replace [`warn: Log.info`](https://github.com/serut/meteor-coverage/blob/dev-1.0.0-fixes/server/report/report-remap.js#L69) with `warn: console.warn`.
2. Exec `meteor npm run test > output.txt`.
3. You'll see some messages like `Could not find ...` that `remap-istanbul` prints for every file included in the coverage that has no source map.

My intention was printing it as additional info, but when using `Log.info` or `console.log`, it prints absolutely nothing.

### Issue with remap

I should see the message `export coverage using the following format [ remap ]`, but I don't see it in the verbose output.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

