### PR TITLE
Fix meteor 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,43 @@ It's a debug only package, so it does not affect your production build.
 [![Dependency Status](https://img.shields.io/david/serut/meteor-coverage.svg)](https://david-dm.org/serut/meteor-coverage)
 [![devDependency Status](https://img.shields.io/david/dev/serut/meteor-coverage.svg)](https://david-dm.org/serut/meteor-coverage?type=dev)
 
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+  - [Installation](#installation)
+    - [Specific setup for Meteor apps](#specific-setup-for-meteor-apps)
+    - [Specific setup for Meteor package](#specific-setup-for-meteor-package)
+    - [Configuration](#configuration)
+  - [Usage](#usage)
+    - [Watch mode](#watch-mode)
+    - [Using runners](#using-runners)
+    - [Run options](#run-options)
+  - [Setup spacejam](#setup-spacejam)
+  - [Advanced setup for CI](#advanced-setup-for-ci)
+    - [Coveralls](#coveralls)
+    - [Codecov](#codecov)
+  - [spacejam --coverage possibilities](#spacejam---coverage-possibilities)
+  - [Meteor --settings file](#meteor---settings-file)
+  - [Global environment variable](#global-environment-variable)
+  - [Config file](#config-file)
+  - [Flow router issue](#flow-router-issue)
+  - [My files are missing from my app coverage report](#my-files-are-missing-from-my-app-coverage-report)
+  - [Istanbul html colors legend](#istanbul-html-colors-legend)
+  - [Ignore code from coverage with annotation](#ignore-code-from-coverage-with-annotation)
+  - [Meteor ignored folders and files](#meteor-ignored-folders-and-files)
+  - [How to replace spacejam](#how-to-replace-spacejam)
+  - [I want my reports referred to my original source files](#i-want-my-reports-referred-to-my-original-source-files)
+  - [Client API](#client-api)
+      - [Meteor.sendCoverage(callback)](#meteorsendcoveragecallback)
+      - [Meteor.exportCoverage(type, callback)](#meteorexportcoveragetype-callback)
+      - [Meteor.importCoverage(callback)](#meteorimportcoveragecallback)
+  - [Contributing](#contributing)
+  - [Credits](#credits)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Installation
 
 ### Specific setup for Meteor apps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "meteor-coverage",
+  "version": "1.1.4",
+  "lockfileVersion": 1
+}

--- a/package.js
+++ b/package.js
@@ -41,6 +41,8 @@ Npm.depends({
 Package.onTest(function (api) {
   api.use('ecmascript');
   api.use(['lmieulet:meteor-coverage-self-instrumenter@3.0.0'], ['server']);
+  // use the right version of coffeescript https://github.com/meteor/meteor/issues/8577#issuecomment-341354360
+  api.use(['coffeescript@1.12.7_3']);
   api.use(['practicalmeteor:mocha', 'practicalmeteor:chai', 'practicalmeteor:sinon', 'lmieulet:meteor-coverage']);
   api.use('jquery', 'client');
 

--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.versionsFrom('METEOR@1.4');
+  api.versionsFrom('METEOR@1.6');
   api.use(['meteorhacks:picker@1.0.3'], 'server');
 
   api.use(['ecmascript']);
@@ -29,14 +29,20 @@ Package.onUse(function (api) {
 });
 
 
-Npm.depends({
-  'istanbul-api': '1.1.0-alpha.1',
-  'body-parser': '1.15.2',
-  'homedir': '0.6.0',
-  'minimatch': '3.0.3',
-  'mkdirp': '0.5.1',
-  'remap-istanbul': '0.6.4'
-});
+Npm.depends({ 
+  "istanbul-lib-source-maps": "1.2.2",
+  "istanbul-lib-instrument": "1.9.1",
+  "istanbul-lib-hook": "1.1.0",
+  "istanbul-lib-coverage": "1.1.1",
+  "istanbul-lib-report": "1.1.2",
+  "istanbul-reports": "1.1.3",
+  "body-parser": "1.18.2",
+  "minimatch": "3.0.4",
+  "mkdirp": "0.5.1",
+  "homedir": "0.6.0",
+  "remap-istanbul": "0.6.4"
+}); 
+ 
 
 Package.onTest(function (api) {
   api.use('ecmascript');

--- a/package.json
+++ b/package.json
@@ -4,10 +4,17 @@
   "description": "A meteor package that allows you to get the statement, line, function and branch coverage of Meteor project and package.   This package uses the [istanbuljs/istanbul-api](https://github.com/istanbuljs/istanbul-api) package for coverage report.   It's a debug only package, so it does not affect your production build.",
   "main": "server/index.js",
   "dependencies": {
-    "istanbul-api": "1.1.0-alpha.1",
-    "body-parser": "1.15.2",
-    "minimatch": "3.0.3",
-    "mkdirp": "0.5.1"
+    "istanbul-lib-source-maps": "1.2.2",
+    "istanbul-lib-instrument": "1.9.1",
+    "istanbul-lib-hook": "1.1.0",
+    "istanbul-lib-coverage": "1.1.1",
+    "istanbul-lib-report": "1.1.2",
+    "istanbul-reports": "1.1.3",
+    "body-parser": "1.18.2",
+    "minimatch": "3.0.4",
+    "mkdirp": "0.5.1",
+    "homedir": "0.6.0",
+    "remap-istanbul": "0.6.4"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/server/report/report-common.js
+++ b/server/report/report-common.js
@@ -2,9 +2,8 @@ import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
 import Log from './../context/log';
+const Report = Npm.require('istanbul-lib-report');
 
-const istanbulAPI = Npm.require('istanbul-api'),
-  Report = istanbulAPI.libReport;
 
 export default ReportCommon = {
     /**

--- a/server/report/report-generic.js
+++ b/server/report/report-generic.js
@@ -2,9 +2,8 @@ import CoverageData from './../services/coverage-data';
 import Core from './../services/core';
 import ReportCommon from './report-common';
 import Conf from '../context/conf';
-
-const istanbulAPI = Npm.require('istanbul-api'),
-  ReportImpl = istanbulAPI.reportsImpl;
+const ReportImpl = Npm.require('istanbul-reports');
+  
 /**
  * Used by type lcovonly and json
  * create the corresponding file using istanbul api

--- a/server/report/report-html.js
+++ b/server/report/report-html.js
@@ -4,9 +4,9 @@ import fs from 'fs';
 import path from 'path';
 import ReportCommon from './report-common';
 import Log from './../context/log';
-var istanbulAPI = Npm.require('istanbul-api'),
-  Report = istanbulAPI.libReport,
-  ReportImpl = istanbulAPI.reportsImpl;
+const Report = Npm.require('istanbul-lib-report'),
+  ReportImpl = Npm.require('istanbul-reports');
+
 export default class {
   constructor(res, options) {
     this.res = res;

--- a/server/report/report-http.js
+++ b/server/report/report-http.js
@@ -1,14 +1,13 @@
 import CoverageData from '../services/coverage-data';
 import Conf from '../context/conf';
 import Core from '../services/core';
-// If we change Npm.require('istanbul-api') into import a from 'istanbul-api'
+// If we change Npm.require('istanbul-reports') into import a from 'istanbul-reports'
 // the __dirname change and the  istanbul dependency fails
 // See istanbul-reports
 // With Npm.require : /Users/Leo/Webstorm/meteor-container/packages/meteor-coverage/.npm/package/node_modules/istanbul-reports/lib/json
 
-var istanbulAPI = Npm.require('istanbul-api'),
-  Report = istanbulAPI.libReport,
-  ReportImpl = istanbulAPI.reportsImpl;
+const Report = Npm.require('istanbul-lib-report'),
+  ReportImpl = Npm.require('istanbul-reports');
 export default class {
   constructor(res, options) {
     this.res = res;
@@ -77,7 +76,7 @@ export default class {
     return context;
   }
 
-    // Istanbul-api expect to save HTML report to the file system and not over network
+    // istanbul-reports expect to save HTML report to the file system and not over network
   alterFS(res) {
     res.close = function () {
       this.end();

--- a/server/report/report-json-summary.js
+++ b/server/report/report-json-summary.js
@@ -2,8 +2,8 @@ import Conf from './../context/conf';
 import CoverageData from './../services/coverage-data';
 import Core from './../services/core';
 import ReportCommon from './report-common';
-const istanbulAPI = Npm.require('istanbul-api'),
-  ReportImpl = istanbulAPI.reportsImpl;
+const ReportImpl = Npm.require('istanbul-reports');
+
 export default class {
   constructor(res, type, options) {
     this.res = res;

--- a/server/report/report-teamcity.js
+++ b/server/report/report-teamcity.js
@@ -3,8 +3,7 @@ import CoverageData from './../services/coverage-data';
 import Core from './../services/core';
 import ReportCommon from './report-common';
 
-var istanbulAPI = Npm.require('istanbul-api'),
-  ReportImpl = istanbulAPI.reportsImpl;
+const ReportImpl = Npm.require('istanbul-reports');
 
 export default class {
   constructor(res, options) {

--- a/server/report/report-text-summary.js
+++ b/server/report/report-text-summary.js
@@ -4,10 +4,9 @@ import Core from '../services/core';
 import ReportCommon from './report-common';
 import path from 'path';
 import fs from 'fs';
-var istanbulAPI = Npm.require('istanbul-api'),
-  Report = istanbulAPI.libReport,
-  ReportImpl = istanbulAPI.reportsImpl;
-
+var Report = Npm.require('istanbul-lib-report'),
+  ReportImpl = Npm.require('istanbul-reports');
+  
 export default class {
   constructor(res, type, options) {
     this.res = res;

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -1,8 +1,7 @@
 import Conf from './../context/conf';
 import path from 'path';
 import fs from 'fs';
-const istanbulAPI = Npm.require('istanbul-api');
-const Coverage = istanbulAPI.libCoverage;
+const Coverage = Npm.require('istanbul-lib-coverage');
 
 let mergeCoverageWith, importCoverage, getCoverageObject;
 

--- a/server/services/coverage-data.js
+++ b/server/services/coverage-data.js
@@ -3,9 +3,8 @@ import Instrumenter from './instrumenter';
 import path from 'path';
 import fs from 'fs';
 
-const istanbulAPI = Npm.require('istanbul-api');
-const Report = istanbulAPI.libReport;
-const Coverage = istanbulAPI.libCoverage;
+const Coverage = Npm.require('istanbul-lib-coverage');
+const Report = Npm.require('istanbul-lib-report');
 
 export default CoverageData = {
   filterCoverageReport: function (report) {

--- a/server/services/instrumenter.js
+++ b/server/services/instrumenter.js
@@ -2,11 +2,8 @@ import {_} from 'meteor/underscore';
 import Log from './../context/log';
 import Conf from './../context/conf';
 import minimatch from 'minimatch';
-
-const istanbulAPI = Npm.require('istanbul-api');
-const Instrument = istanbulAPI.libInstrument;
-const Hook = istanbulAPI.libHook;
-
+const Instrument  = Npm.require('istanbul-lib-instrument'),
+     Hook = Npm.require('istanbul-lib-hook');
 let instrumenter = undefined;
 
 /**

--- a/server/services/source-map.js
+++ b/server/services/source-map.js
@@ -4,8 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 const homedir = Npm.require('homedir');
-const istanbulAPI = Npm.require('istanbul-api');
-const libSourceMaps = istanbulAPI.libSourceMaps;
+const libSourceMaps = Npm.require('istanbul-lib-source-maps');
 
 const sourceMap = libSourceMaps.createSourceMapStore({verbose: Conf.IS_COVERAGE_ACTIVE});
 const meteorDir = Conf.COVERAGE_APP_FOLDER;


### PR DESCRIPTION
Migrate to the last repo of istanbul. There is no downside so far, client files are well instrumented and library is well wired. But I don't have any server app to test with.
Fix #53 #54 
 
The current version of `istanbul-lib-hook`, v1.1.0, does not support requires made by meteor v1.6. So we need to wait they merge the PR, then we will use their release. Meteor v1.6 is ok so far.

## Test environnement
Tested on meteor app v1.6 with [istanbuljs/istanbuljs PR #99](https://github.com/istanbuljs/istanbuljs/pull/99)  : I patched files on `meteor-starter-kit\packages\meteor-coverage\.npm\package\node_modules\istanbul-lib-hook` using https://github.com/CodeTroopers/istanbuljs codebase
```
meteor-starter-kit> meteor npm run coverage-watch:app-unit
> meteor-starter-kit@ coverage-watch:app-unit C:\Users\serut\dev\meteor-starter-kit
> meteor test --settings settings.coverage.json --driver-package practicalmeteor:mocha
[[[[[ Tests ]]]]]

=> Started proxy.
=> Started MongoDB.
I20171105-21:48:19.192(1)? Coverage active
I20171105-21:48:19.193(1)? Reading custom configuration
I20171105-21:48:19.195(1)? [Configuration]  { include:
I20171105-21:48:19.195(1)?    [ '**/Local/Temp/meteor-test-*/**',
I20171105-21:48:19.196(1)?      '**/local/build/programs/server/app/app.js' ] }
I20171105-21:48:19.197(1)? Loading default configuration: exclude.*
I20171105-21:48:19.198(1)? Loading default configuration: output
I20171105-21:48:19.199(1)? Loading default configuration: remapFormat
I20171105-21:48:19.199(1)? Coverage configuration:
I20171105-21:48:19.200(1)? - IS_COVERAGE_ACTIVE= true
I20171105-21:48:19.201(1)? - IS_COVERAGE_VERBOSE= true
I20171105-21:48:19.202(1)? - COVERAGE_APP_FOLDER= C:\Users\serut\dev\meteor-starter-kit\
I20171105-21:48:19.203(1)? .coverage.json values:
I20171105-21:48:19.204(1)? - exclude= { general: [],
I20171105-21:48:19.205(1)?   server:
I20171105-21:48:19.206(1)?    [ '**/node_modules/**/*.json',
I20171105-21:48:19.206(1)?      '**/.!(meteor)*/**',
I20171105-21:48:19.207(1)?      '**/packages/!(local-test_?*.js)',
I20171105-21:48:19.208(1)?      '**/+([^:]):+([^:])/**',
I20171105-21:48:19.209(1)?      '**/@(test|tests|spec|specs)/**',
I20171105-21:48:19.209(1)?      '**/?(*.)test?(s).?*',
I20171105-21:48:19.210(1)?      '**/?(*.)spec?(s).?*',
I20171105-21:48:19.211(1)?      '**/?(*.)app-test?(s).?*',
I20171105-21:48:19.211(1)?      '**/?(*.)app-spec?(s).?*' ],
I20171105-21:48:19.213(1)?   client:
I20171105-21:48:19.214(1)?    [ '**/*.json',
I20171105-21:48:19.215(1)?      '**/client/stylesheets/**',
I20171105-21:48:19.215(1)?      '**/.npm/package/node_modules/**',
I20171105-21:48:19.216(1)?      '**/web.browser/packages/**',
I20171105-21:48:19.217(1)?      '**/.?*/**',
I20171105-21:48:19.218(1)?      '**/packages/!(local-test_?*.js)',
I20171105-21:48:19.218(1)?      '**/+([^:]):+([^:])/**',
I20171105-21:48:19.219(1)?      '**/@(test|tests|spec|specs)/**',
I20171105-21:48:19.220(1)?      '**/?(*.)test?(s).?*',
I20171105-21:48:19.220(1)?      '**/?(*.)spec?(s).?*',
I20171105-21:48:19.221(1)?      '**/?(*.)app-test?(s).?*',
I20171105-21:48:19.223(1)?      '**/?(*.)app-spec?(s).?*' ] }
I20171105-21:48:19.224(1)? - include= [ '**/Local/Temp/meteor-test-*/**',
I20171105-21:48:19.225(1)?   '**/local/build/programs/server/app/app.js' ]
I20171105-21:48:19.226(1)? - remapFormat= [ 'html',
I20171105-21:48:19.226(1)?   'cobertura',
I20171105-21:48:19.227(1)?   'clover',
I20171105-21:48:19.228(1)?   'json',
I20171105-21:48:19.228(1)?   'json-summary',
I20171105-21:48:19.229(1)?   'lcovonly',
I20171105-21:48:19.229(1)?   'teamcity',
I20171105-21:48:19.230(1)?   'text',
I20171105-21:48:19.231(1)?   'text-summary' ]
I20171105-21:48:19.232(1)? - COVERAGE_EXPORT_FOLDER= ./.coverage
I20171105-21:48:20.007(1)? [ServerSide][OutsideApp] file ignored: <path>\body-parser\lib\types\urlencoded.js
I20171105-21:48:20.009(1)? [ServerSide][OutsideApp] file ignored: <path>\bytes\index.js
I20171105-21:48:20.011(1)? [ServerSide][OutsideApp] file ignored: <path>\content-type\index.js
I20171105-21:48:20.013(1)? [ServerSide][OutsideApp] file ignored: <path>\http-errors\index.js
I20171105-21:48:20.015(1)? [ServerSide][OutsideApp] file ignored: <path>\setprototypeof\index.js
I20171105-21:48:20.017(1)? [ServerSide][OutsideApp] file ignored: <path>\statuses\index.js
I20171105-21:48:20.022(1)? [ServerSide][OutsideApp] file ignored: <path>\body-parser\node_modules\debug\src\index.js
I20171105-21:48:20.023(1)? [ServerSide][OutsideApp] file ignored: <path>\body-parser\node_modules\debug\src\node.js
I20171105-21:48:20.024(1)? [ServerSide][OutsideApp] file ignored: <path>\body-parser\node_modules\debug\src\debug.js
I20171105-21:48:20.028(1)? [ServerSide][OutsideApp] file ignored: <path>\body-parser\lib\read.js
I20171105-21:48:20.031(1)? [ServerSide][OutsideApp] file ignored: <path>\raw-body\index.js
I20171105-21:48:20.034(1)? [ServerSide][OutsideApp] file ignored: <path>\iconv-lite\lib\index.js
I20171105-21:48:20.035(1)? [ServerSide][OutsideApp] file ignored: <path>\iconv-lite\lib\bom-handling.js
I20171105-21:48:20.037(1)? [ServerSide][OutsideApp] file ignored: <path>\iconv-lite\lib\streams.js
I20171105-21:48:20.038(1)? [ServerSide][OutsideApp] file ignored: <path>\iconv-lite\lib\extend-node.js
I20171105-21:48:20.040(1)? [ServerSide][OutsideApp] file ignored: <path>\unpipe\index.js
I20171105-21:48:20.042(1)? [ServerSide][OutsideApp] file ignored: <path>\on-finished\index.js
I20171105-21:48:20.043(1)? [ServerSide][OutsideApp] file ignored: <path>\ee-first\index.js
I20171105-21:48:20.045(1)? [ServerSide][OutsideApp] file ignored: <path>\type-is\index.js
I20171105-21:48:20.047(1)? [ServerSide][OutsideApp] file ignored: <path>\media-typer\index.js
I20171105-21:48:20.049(1)? [ServerSide][OutsideApp] file ignored: <path>\mime-types\index.js
I20171105-21:48:20.051(1)? [ServerSide][OutsideApp] file ignored: <path>\mime-db\index.js
I20171105-21:48:20.058(1)? [ServerSide][OutsideApp] file ignored: <path>\body-parser\lib\types\json.js
I20171105-21:48:20.062(1)? [ServerSide][OutsideApp] file ignored: <path>\.meteor\packages\tmeasday_check-npm-versions\0.3.1\npm\node_modules\semver\semver.js
I20171105-21:48:20.068(1)? [ServerSide][OutsideApp] file ignored: <path>\node_modules\react\react.js
[Then the app stops to boot)
```

If I do not replace `meteor-starter-kit\packages\meteor-coverage\.npm\package\node_modules\istanbul-lib-hook` with the istanbuljs PR I don't get any logs `[ServerSide][OutsideApp] file ignored: `