### PR TITLE
Replace `meteorhacks:picker` by `webapp`

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,9 +9,9 @@ Package.describe({
 
 Package.onUse(function (api) {
   api.versionsFrom('METEOR@1.4');
-  api.use(['meteorhacks:picker@1.0.3'], 'server');
 
   api.use(['ecmascript']);
+  api.use('webapp', 'server');
   // Add datasets
   api.addAssets('conf/default-coverage.json', 'server');
 


### PR DESCRIPTION
## Description

This PR replaces the outdated package [`meteorhacks:picker`](https://github.com/meteorhacks/picker) by the package [`webapp`](https://docs.meteor.com/packages/webapp.html).

As `picker` is just a small package on top of `webapp` it was not much work required here to get a suitable replacement.

## Motivation and Context

This solves https://github.com/serut/meteor-coverage/issues/62 which is inspired by https://github.com/meteor/meteor/issues/9653#issuecomment-364660813

## How Has This Been Tested?

I've opened the coverage in the browser, called all the requests on the client and verified that the client-coverage was sent and is shown.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
