### PR TITLE
Replaced the practicalmeteor packages

### DIFF
--- a/client/methods.e2e.tests.js
+++ b/client/methods.e2e.tests.js
@@ -1,4 +1,4 @@
-import {chai, assert, expect} from 'meteor/practicalmeteor:chai';
+import {chai, assert, expect} from 'chai';
 import Meteor from 'meteor/lmieulet:meteor-coverage';
 var _should = chai.should();
 

--- a/client/methods.tests.js
+++ b/client/methods.tests.js
@@ -1,6 +1,6 @@
 import { $ } from 'meteor/jquery';
-import { expect, assert } from 'meteor/practicalmeteor:chai';
-import { sinon } from 'meteor/practicalmeteor:sinon';
+import { expect, assert } from 'chai';
+import sinon from 'sinon';
 import Meteor from 'meteor/lmieulet:meteor-coverage';
 
 describe('meteor-coverage', function (done) {

--- a/client/methods.unit.tests.js
+++ b/client/methods.unit.tests.js
@@ -1,6 +1,6 @@
 import {$} from 'meteor/jquery';
-import {expect, assert} from 'meteor/practicalmeteor:chai';
-import {sinon} from 'meteor/practicalmeteor:sinon';
+import {expect, assert} from 'chai';
+import sinon from 'sinon';
 import Meteor from 'meteor/lmieulet:meteor-coverage';
 
 describe('meteor-coverage', function (done) {

--- a/package.js
+++ b/package.js
@@ -26,24 +26,35 @@ Package.onUse(function (api) {
 
   api.mainModule('server/index.js', 'server');
   api.mainModule('client/methods.js', 'client');
-});
 
-
-Npm.depends({
-  'istanbul-api': '1.1.0-alpha.1',
-  'body-parser': '1.15.2',
-  'homedir': '0.6.0',
-  'minimatch': '3.0.3',
-  'mkdirp': '0.5.1',
-  'remap-istanbul': '0.6.4'
+  Npm.depends({
+    'istanbul-api': '1.1.0-alpha.1',
+    'body-parser': '1.15.2',
+    'homedir': '0.6.0',
+    'minimatch': '3.0.3',
+    'mkdirp': '0.5.1',
+    'remap-istanbul': '0.6.4'
+  });
 });
 
 Package.onTest(function (api) {
   api.use('ecmascript');
   api.use(['lmieulet:meteor-coverage-self-instrumenter@3.0.0'], ['server']);
-  api.use(['practicalmeteor:mocha', 'practicalmeteor:chai', 'practicalmeteor:sinon', 'lmieulet:meteor-coverage']);
-  api.use('jquery', 'client');
+  api.use(['lmieulet:meteor-coverage']);
+  api.use(['meteortesting:mocha']);
 
   api.mainModule('server/tests.js', 'server');
   api.mainModule('client/main.tests.js', 'client');
+
+  Npm.depends({
+    chai: '2.1.0',
+    sinon: '1.14.1',
+
+    'istanbul-api': '1.1.0-alpha.1',
+    'body-parser': '1.15.2',
+    'homedir': '0.6.0',
+    'minimatch': '3.0.3',
+    'mkdirp': '0.5.1',
+    'remap-istanbul': '0.6.4'
+  });
 });

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "spacejam": "https://github.com/serut/spacejam/tarball/windows-suppport-rc4"
   },
   "scripts": {
-    "test": "spacejam test-packages ./ --coverage out_lcovonly  --driver-package practicalmeteor:mocha-console-runner",
-    "test:watch": "meteor test-packages ./ --settings settings.coverage.json  --driver-package practicalmeteor:mocha",
+    "test": "COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ meteor test-packages ./ --driver-package meteortesting:mocha",
+    "test:watch": "COVERAGE=1 COVERAGE_APP_FOLDER=$PWD/ meteor test-packages ./  --driver-package meteortesting:mocha --watch",
     "start": "meteor npm run lint:fix & meteor npm run test:watch",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",

--- a/server/tests.js
+++ b/server/tests.js
@@ -1,4 +1,4 @@
-import {assert} from 'meteor/practicalmeteor:chai';
+import {assert} from 'chai';
 
 import meteorCoverageApi from 'meteor/lmieulet:meteor-coverage';
 


### PR DESCRIPTION
## Description

In this PR, I've replaced practicalmeteor:mocha`, `practicalmeteor:chai` and `practicalmeteor:sinon` by `meteortesting:mocha` and the npm packages for `chai` and `sinon`.

## Motivation and Context

The main motivation behind this was the update to Meteor 1.6.1, where coffeescript2 is used which is not supported by either of the packages listed above. I've therefore replaced them as suggested here: https://github.com/meteor/meteor/pull/9107#issuecomment-338508621

## How Has This Been Tested?

Ran the tests and everything worked.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
