### PR TITLE
Replaced jQuery by the package HTTP

### DIFF
--- a/client/client.instrumentation.tests.js
+++ b/client/client.instrumentation.tests.js
@@ -1,3 +1,5 @@
+import { HTTP } from 'meteor/http';
+
 describe('meteor-coverage', function (done) {
 
   it('download a lot of times the same a client js script, ensure they are not corrumpted', function (done) {
@@ -6,18 +8,14 @@ describe('meteor-coverage', function (done) {
     let i = 0;
     const downloadPageAndCheckLength = function (i) {
       // meteor-coverage package is a ES6 package
-      let request = $.ajax({
-        type: 'GET',
-        url: '/packages/lmieulet_meteor-coverage.js',
-        success: function () {
-          if (request.getResponseHeader('Content-Length') > 5000000) {
-            if (i < 5000) {
-              return downloadPageAndCheckLength(i+1);
-            }
-            return done();
+      HTTP.get('/packages/lmieulet_meteor-coverage.js', {}, (error, response) => {
+        if (response.content.length > 5000000) {
+          if (i < 5000) {
+            return downloadPageAndCheckLength(i+1);
           }
-          return done(request.getResponseHeader('Content-Length'), 'Request returned as corrumpted');
+          return done();
         }
+        return done(response.content.length, 'Request returned as corrumpted');
       });
     };
     downloadPageAndCheckLength(i);

--- a/client/methods.e2e.tests.js
+++ b/client/methods.e2e.tests.js
@@ -35,28 +35,6 @@ describe('meteor-coverage', function () {
       done(e);
     }
   });
-  /*it('handle errors on sending client coverage', function (done) {
-    // Manual stub
-    const _jQueryAjaxBackup = $.ajax;
-    $.ajax = function(options) { options.error(); };
-
-    try {
-      Meteor.sendCoverage(
-        function (stats, err) {
-          assert.isTrue(stats.TOTAL > 0, 'no client coverage');
-          assert.isTrue(stats.SUCCESS > 0, 'none of the client coverage have been saved');
-          assert.isTrue(stats.FAILED > 0, 'an export failed');
-          done();
-        }
-      );
-    } catch (e) {
-      console.error(e, e.stack);
-      done(e);
-    }
-
-    // Undo stub
-    $.ajax = _jQueryAjaxBackup;
-  });*/
 
   // test implemented report types
   let coverage = {

--- a/client/methods.js
+++ b/client/methods.js
@@ -1,4 +1,4 @@
-import { $ } from 'meteor/jquery';
+import { HTTP } from 'meteor/http';
 import { Meteor } from 'meteor/meteor';
 
 var stats = {SUCCESS: 0, FAILED: 0, TOTAL: 0};
@@ -33,23 +33,7 @@ Meteor.getCoverageReportObject = function (propertyKey, value) {
 * Usage: Meteor.sendCoverage(function(stats,err) {console.log(stats,err);});
 */
 Meteor.sendCoverage = function (callback) {
-  var coverageReport = {},
-    successCallback = function () {
-      Meteor.increaseSuccess();
-      var stats = Meteor.getStats();
-      /* istanbul ignore else */
-      if (stats.SUCCESS + stats.FAILED === stats.TOTAL) {
-        callback(stats);
-      }
-    },
-    errorCallback = function() {
-      Meteor.increaseFailures();
-      var stats = Meteor.getStats();
-      /* istanbul ignore else */
-      if (stats.SUCCESS + stats.FAILED === stats.TOTAL) {
-        callback(stats, arguments);
-      }
-    };
+  var coverageReport = {};
 
   var globalCoverage = Meteor.getCoverageObject();
   if (!globalCoverage) {
@@ -62,14 +46,23 @@ Meteor.sendCoverage = function (callback) {
     if (globalCoverage.hasOwnProperty(property)) {
       Meteor.increaseTotal();
 
-      $.ajax({
-        method: 'POST',
-        url: '/coverage/client',
-        data: Meteor.getCoverageReportObject(property, globalCoverage[property]),
-        contentType: 'application/json; charset=UTF-8',
-        processData: false,
-        success: successCallback,
-        error: errorCallback
+      HTTP.call('POST', '/coverage/client', {
+        content: Meteor.getCoverageReportObject(property, globalCoverage[property]),
+        headers: {
+          'Content-Type': 'application/json; charset=UTF-8'
+        }
+      }, (error, res) => {
+        if (error) {
+          Meteor.increaseFailures();
+        } else {
+          Meteor.increaseSuccess();
+        }
+
+        var stats = Meteor.getStats();
+        /* istanbul ignore else */
+        if (stats.SUCCESS + stats.FAILED === stats.TOTAL) {
+          callback(stats, arguments);
+        }
       });
     }
   }
@@ -80,24 +73,21 @@ Meteor.sendCoverage = function (callback) {
 Meteor.exportCoverage = function (type, callback) {
   /* istanbul ignore next: ternary operator */
   var url = type ? '/coverage/export/'+type : '/coverage/export';
-  $.ajax({
-    method: 'GET',
-    url: url,
-    success: function(data) {
-      try {
-        let result = JSON.parse(data);
-        /* istanbul ignore else */
-        if (result.type !== 'success') {
-          throw new Error('Error: '+JSON.stringify(arguments)+'. An unexpected error occurred while trying to export coverage data');
-        }
+  HTTP.call('GET', url, {}, (error, res) => {
+    if (error) {
+      return callback('Error: '+JSON.stringify(arguments)+'. A server error occurred while trying to export coverage data');
+    }
 
-        return callback();
-      } catch (e) {
-        return callback(e);
+    try {
+      let result = JSON.parse(res.content);
+      /* istanbul ignore else */
+      if (result.type !== 'success') {
+        throw new Error('Error: '+JSON.stringify(arguments)+'. An unexpected error occurred while trying to export coverage data');
       }
-    },
-    error: function() {
-      callback('Error: '+JSON.stringify(arguments)+'. A server error occurred while trying to export coverage data');
+
+      return callback();
+    } catch (e) {
+      return callback(e);
     }
   });
 };
@@ -106,24 +96,21 @@ Meteor.exportCoverage = function (type, callback) {
 * Usage: Meteor.importCoverage(function(err) {console.log(err)})
 */
 Meteor.importCoverage = function (callback) {
-  $.ajax({
-    method: 'GET',
-    url: '/coverage/import',
-    success: function(data) {
-      try {
-        let result = JSON.parse(data);
-        /* istanbul ignore else */
-        if (result.type !== 'success') {
-          throw new Error('Error: '+JSON.stringify(arguments)+'. An unexpected error occurred while trying to import coverage data');
-        }
+  HTTP.call('GET', '/coverage/import', {}, (error, res) => {
+    if (error) {
+      return callback(error, [error]);
+    }
 
-        return callback();
-      } catch (e) {
-        callback(e, arguments);
+    try {
+      let result = JSON.parse(res.content);
+      /* istanbul ignore else */
+      if (result.type !== 'success') {
+        throw new Error('Error: '+JSON.stringify(arguments)+'. An unexpected error occurred while trying to import coverage data');
       }
-    },
-    error: function() {
-      callback(e, arguments);
+
+      return callback();
+    } catch (e) {
+      callback(e, [res]);
     }
   });
 };

--- a/client/methods.tests.js
+++ b/client/methods.tests.js
@@ -1,4 +1,4 @@
-import { $ } from 'meteor/jquery';
+import { HTTP } from 'meteor/http';
 import { expect, assert } from 'meteor/practicalmeteor:chai';
 import { sinon } from 'meteor/practicalmeteor:sinon';
 import Meteor from 'meteor/lmieulet:meteor-coverage';
@@ -33,8 +33,8 @@ describe('meteor-coverage', function (done) {
     const callback = sandbox.spy();
 
     sandbox.stub(Meteor, 'getCoverageObject').returns({ 'web.browser': { path: 1} });
-    sandbox.stub($, 'ajax', function(config) {
-      config.success();
+    sandbox.stub(HTTP, 'post', function(url, config, callback) {
+      callback();
     });
 
     Meteor.sendCoverage(callback);
@@ -45,8 +45,8 @@ describe('meteor-coverage', function (done) {
     const callback = sandbox.spy();
 
     sandbox.stub(JSON, 'parse').returns({ type: 'success'});
-    sandbox.stub($, 'ajax', function(config) {
-      config.success();
+    sandbox.stub(HTTP, 'get', function(url, config, callback) {
+      callback();
     });
 
     Meteor.exportCoverage('test', callback);
@@ -57,8 +57,8 @@ describe('meteor-coverage', function (done) {
     const callback = sandbox.spy();
 
     sandbox.stub(JSON, 'parse').returns({ type: 'success'});
-    sandbox.stub($, 'ajax', function(config) {
-      config.success();
+    sandbox.stub(HTTP, 'get', function(url, config, callback) {
+      callback();
     });
 
     Meteor.importCoverage(callback);

--- a/client/methods.unit.tests.js
+++ b/client/methods.unit.tests.js
@@ -1,4 +1,4 @@
-import {$} from 'meteor/jquery';
+import { HTTP } from 'meteor/http';
 import {expect, assert} from 'meteor/practicalmeteor:chai';
 import {sinon} from 'meteor/practicalmeteor:sinon';
 import Meteor from 'meteor/lmieulet:meteor-coverage';
@@ -33,8 +33,8 @@ describe('meteor-coverage', function (done) {
     const callback = sandbox.spy();
 
     sandbox.stub(Meteor, 'getCoverageObject').returns({'web.browser': {path: 1}});
-    sandbox.stub($, 'ajax', function (config) {
-      config.success();
+    sandbox.stub(HTTP, 'post', function(url, config, callback) {
+      callback();
     });
 
     Meteor.sendCoverage(callback);
@@ -45,8 +45,8 @@ describe('meteor-coverage', function (done) {
     const callback = sandbox.spy();
 
     sandbox.stub(JSON, 'parse').returns({type: 'success'});
-    sandbox.stub($, 'ajax', function (config) {
-      config.success();
+    sandbox.stub(HTTP, 'get', function(url, config, callback) {
+      callback();
     });
 
     Meteor.exportCoverage('test', callback);
@@ -57,8 +57,8 @@ describe('meteor-coverage', function (done) {
     const callback = sandbox.spy();
 
     sandbox.stub(JSON, 'parse').returns({type: 'success'});
-    sandbox.stub($, 'ajax', function (config) {
-      config.success();
+    sandbox.stub(HTTP, 'get', function(url, config, callback) {
+      callback();
     });
 
     Meteor.importCoverage(callback);

--- a/package.js
+++ b/package.js
@@ -12,6 +12,7 @@ Package.onUse(function (api) {
   api.use(['meteorhacks:picker@1.0.3'], 'server');
 
   api.use(['ecmascript']);
+  api.use('http', 'client');
   // Add datasets
   api.addAssets('conf/default-coverage.json', 'server');
 
@@ -43,6 +44,7 @@ Package.onTest(function (api) {
   api.use(['lmieulet:meteor-coverage-self-instrumenter@3.0.0'], ['server']);
   api.use(['practicalmeteor:mocha', 'practicalmeteor:chai', 'practicalmeteor:sinon', 'lmieulet:meteor-coverage']);
   api.use('jquery', 'client');
+  api.use('http', 'client');
 
   api.mainModule('server/tests.js', 'server');
   api.mainModule('client/main.tests.js', 'client');


### PR DESCRIPTION
## Description

jQuery is an undocumented dependency of this package which I discovered lately. 

## Motivation and Context

Since jQuery is only used to send off requests to the server, I decided it to be better to rather use the pacakge [`HTTP`](https://docs.meteor.com/api/http.html) provided by Meteor instead.

## How Has This Been Tested?

I was able to run the tests (by combining it with the changes of https://github.com/serut/meteor-coverage/pull/65) and to actually send off the requests and see their result on the server-side

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
