### PR TITLE
Run eslint before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "spacejam": "https://github.com/serut/spacejam/tarball/windows-suppport-rc4"
   },
   "scripts": {
+    "pretest": "npm run lint --silent",
     "test": "spacejam test-packages ./ --coverage out_lcovonly  --driver-package practicalmeteor:mocha-console-runner",
     "test:watch": "meteor test-packages ./ --settings settings.coverage.json  --driver-package practicalmeteor:mocha",
     "start": "meteor npm run lint:fix & meteor npm run test:watch",

--- a/server/services/source-map.js
+++ b/server/services/source-map.js
@@ -177,14 +177,14 @@ alterSourceMapPaths = function (map, isClientSide) {
       if (file.path === mergedPath) {
         /* istanbul ignore else */
         if (file.node_modules) {
-           try {
-             nodeModulesBase = path.join(abspath.serverSide, file.node_modules);
-             nodeModulesBase = fs.realpathSync(nodeModulesBase); // usually a symlink
+          try {
+            nodeModulesBase = path.join(abspath.serverSide, file.node_modules);
+            nodeModulesBase = fs.realpathSync(nodeModulesBase); // usually a symlink
           } catch (e) {
-             if (e.code === 'ENOENT') {
-               Log.info('File not found!', nodeModulesBase);
+            if (e.code === 'ENOENT') {
+              Log.info('File not found!', nodeModulesBase);
             } else {
-               throw e;
+              throw e;
             }
           }
         }


### PR DESCRIPTION
## Description

Adds the command `pretest` to npm which is called before every `test` command, as documented at https://docs.npmjs.com/misc/scripts

I also had to fix the code style at one place 😉 

## Motivation and Context

I found it tiring to always call `npm lint` so I found it a good fit to call it automatically before calling the tests.

## How Has This Been Tested?

Calling the tests using `npm test` and confirmed that it stopped if the code style was not as required.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
