### PR TITLE
Avoid throwing errors in async context

### DIFF
--- a/server/handlers.js
+++ b/server/handlers.js
@@ -23,14 +23,20 @@ getAsset = function (params, req, res, next) {
         if (!exists) return next();
         fs.readFile(assetsDir + '/vendor/' + filename, function (err, fileContent) {
           /* istanbul ignore else */
-          if (err) throw err;
+          if (err) {
+            console.error(err);
+            return next();
+          }
           res.end(fileContent);
         });
       });
     } else {
       fs.readFile(assetsDir + '/' + filename, function (err, fileContent) {
         /* istanbul ignore else */
-        if (err) throw err;
+        if (err) {
+          console.error(err);
+          return next();
+        }
         res.end(fileContent);
       });
     }

--- a/server/report/report-coverage.js
+++ b/server/report/report-coverage.js
@@ -15,10 +15,10 @@ export default class {
     fs.writeFile(reportPath, coverageReport, function (err) {
       /* istanbul ignore else */
       if (err) {
-        throw 'failed to write report file: ' + reportPath;
+        instance.res.end(JSON.stringify({ type: 'failed', message: 'failed to write report file: ' + reportPath }));
+      } else {
+        instance.res.end('{"type":"success"}');
       }
-      instance.res.end('{"type":"success"}');
     });
-
   }
 }

--- a/server/report/report-html.js
+++ b/server/report/report-html.js
@@ -87,11 +87,11 @@ export default class {
         copyFile: function (sourcePath, destPath) {
           fs.readFile(sourcePath, (err, data) => {
             /* istanbul ignore else */
-            if (err) throw err;
+            if (err) return console.error(err);
             let p = path.join(folderpath, destPath);
             fs.writeFile(p, data, (err, data) => {
               /* istanbul ignore else */
-              if (err) throw err;
+              if (err) return console.error(err);
             });
           });
         }

--- a/server/services/core.js
+++ b/server/services/core.js
@@ -37,12 +37,14 @@ importCoverage = function (res, options = {}) {
   fs.exists(reportPath, function (exists) {
     /* istanbul ignore else */
     if (!exists) {
-      throw 'report file not found: reportPath=' + reportPath + ' COVERAGE_APP_FOLDER=' + Conf.COVERAGE_APP_FOLDER;
+      res.end(JSON.stringify({ type: 'failed', message: 'report file not found: reportPath=' + reportPath + ' COVERAGE_APP_FOLDER=' + Conf.COVERAGE_APP_FOLDER }));
+      return;
     }
     fs.readFile(reportPath, 'utf8', function (err, fileContent) {
       /* istanbul ignore else */
       if (err) {
-        throw 'failed to read report file: ' + reportPath;
+        res.end(JSON.stringify({ type: 'failed', message: 'failed to read report file: ' + reportPath }));
+        return;
       }
       let coverageObj = JSON.parse(fileContent);
       for (let property in coverageObj) {


### PR DESCRIPTION
## Description

Replaced all throwing of errors in an async context by some equivalent that should be noticed.

## Motivation and Context

Mainly because rejected promises will terminate a node-process in future versions of node, I wanted to make sure that errors in other async contexts are correctly reported and the execution of the rest is stopped.

Before this change, some of the responses to the client just raised an error because the response was no valid JSON. This is now fixed as in these conditions, proper JSON is returned.

## How Has This Been Tested?

I've tested the new responses - not really the places where I replaced it as `console.error()` but this will clearly receive notice on the console-output.

## Screenshots (if appropriate):

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
