### PR TITLE
Make compatible with Meteor 2.3

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,7 +17,7 @@ const dependencies = {
 };
 
 Package.onUse(function (api) {
-  api.versionsFrom('METEOR@1.8');
+  api.versionsFrom(['1.8', '2.3']);
 
   api.use(['ecmascript']);
   api.use('webapp', 'server');


### PR DESCRIPTION
## Description

Add to `api.versionsFrom` `2.3` so that it is compatible with this newer version of Meteor. This is needed due to `http` package having a major version bump.